### PR TITLE
formatters/index : format needs to specify default 3rd arg

### DIFF
--- a/packages/react-sdk-components/src/components/helpers/formatters/index.js
+++ b/packages/react-sdk-components/src/components/helpers/formatters/index.js
@@ -58,7 +58,7 @@ function parseDateInISO(value) {
   return value ? getDateObject(value).toISOString() : value;
 }
 
-export function format(value, type, options) {
+export function format(value, type, options = {}) {
   let formattedValue;
 
   switch (type?.toLowerCase()) {


### PR DESCRIPTION
TypeScript gives a compiler error in calls with only 2 args so need to specify a default value of 3rd arg (options) to format