### PR TITLE
Fix relative path so it works with overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pega/react-sdk-components",
-  "version": "0.23.13",
+  "version": "0.23.14",
   "description": "React SDK packaging: bridge and components, overrides",
   "main": "index.ts",
   "scripts": {

--- a/packages/react-sdk-components/package.json
+++ b/packages/react-sdk-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pega/react-sdk-components",
-  "version": "0.23.13",
+  "version": "0.23.14",
   "description": "React SDK Infrastructure: bridge and components",
   "_filesComment": "During packing, npm ignores everything NOT in the files list",
   "files": [

--- a/packages/react-sdk-components/src/components/helpers/simpleTableHelpers.ts
+++ b/packages/react-sdk-components/src/components/helpers/simpleTableHelpers.ts
@@ -1,4 +1,4 @@
-import { Utils } from '../../helpers/utils';
+import { Utils } from './utils';
 
 declare const PCore;
 

--- a/packages/react-sdk-components/src/components/template/ListView/ListView.tsx
+++ b/packages/react-sdk-components/src/components/template/ListView/ListView.tsx
@@ -35,7 +35,7 @@ import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import { Radio } from '@material-ui/core';
 import Checkbox from '@material-ui/core/Checkbox';
-import { filterData } from '../SimpleTable/simpleTableHelpers';
+import { filterData } from '../../helpers/simpleTableHelpers';
 import './ListView.css';
 
 const SELECTION_MODE = { SINGLE: 'single', MULTI: 'multi' };

--- a/packages/react-sdk-components/src/components/template/SimpleTable/SimpleTableManual/SimpleTableManual.tsx
+++ b/packages/react-sdk-components/src/components/template/SimpleTable/SimpleTableManual/SimpleTableManual.tsx
@@ -8,7 +8,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import { makeStyles } from '@material-ui/core/styles';
-import { buildFieldsForTable, filterData } from '../simpleTableHelpers';
+import { buildFieldsForTable, filterData } from '../../../helpers/simpleTableHelpers';
 import { getDataPage } from '../../../helpers/data_page';
 import Link from '@material-ui/core/Link';
 import { getReferenceList } from '../../../helpers/field-group-utils';

--- a/packages/react-sdk-overrides/package.json
+++ b/packages/react-sdk-overrides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pega/react-sdk-overrides",
-  "version": "0.23.13",
+  "version": "0.23.14",
   "description": "React SDK - Code for overriding components",
   "_filesComment": "During packing, npm ignores everything NOT in the files list",
   "files": [

--- a/scripts/override-constants.js
+++ b/scripts/override-constants.js
@@ -13,7 +13,6 @@ const sdkTopLevelContent = [ 'components_map' ];
 //  where that file is found
 //  ex: 'TextInput': 'field' indicates that there's TextInput is in the components/field directory
 //    'SimpleTable' is in 'template/SimpleTable/SimpleTable' subdirectory
-//    'simpleTableHelpers' is in template/SimpleTable' directory (a non-component entry in this table)
 const sdkComponentLocationMap = {
   'ActionButtons': 'infra',
   'ActionButtonsForFileUtil': 'widget/FileUtility',
@@ -77,7 +76,6 @@ const sdkComponentLocationMap = {
   'RootContainer': 'infra',
   'SemanticLink': 'field',
   'SimpleTable': 'template/SimpleTable',
-  'simpleTableHelpers': 'template/SimpleTable',
   'SimpleTableManual': 'template/SimpleTable',
   'SimpleTableSelect': 'template/SimpleTable',
   'SingleReferenceReadOnly': 'template',


### PR DESCRIPTION
Moving simpleTableHelpers to helpers folder to be more consistent and to make it work correctly as an override.