### PR TITLE
fix: load user reference properties within Summary

### DIFF
--- a/packages/react-sdk-components/src/components/designSystemExtension/CaseSummaryFields/CaseSummaryFields.tsx
+++ b/packages/react-sdk-components/src/components/designSystemExtension/CaseSummaryFields/CaseSummaryFields.tsx
@@ -124,6 +124,7 @@ export default function CaseSummaryFields(props) {
       case 'datetime':
       case 'currency':
       case 'boolean':
+      case 'userreference':
         return (
           <TextField
             value={format(field.config.value, field.type)}
@@ -137,7 +138,6 @@ export default function CaseSummaryFields(props) {
 
       case 'caseoperator':
         return <Operator caseOpConfig={field.config} />;
-        break;
 
       default:
         return (

--- a/packages/react-sdk-components/src/components/helpers/formatters/index.js
+++ b/packages/react-sdk-components/src/components/helpers/formatters/index.js
@@ -113,6 +113,11 @@ export function format(value, type, options = {}) {
       break;
     }
 
+    case "userreference": {
+      formattedValue = value.userName;
+      break;
+    }
+
     default:
       formattedValue = value;
   }


### PR DESCRIPTION
Currently, the User Reference property is not getting loaded in the Summary panel, so displaying the User Reference value as plain text.