### PR TITLE
0.23.21 updates - add new components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pega/react-sdk-components",
-  "version": "0.23.20",
+  "version": "0.23.21",
   "description": "React SDK packaging: bridge and components, overrides",
   "main": "index.ts",
   "scripts": {

--- a/packages/react-sdk-components/package.json
+++ b/packages/react-sdk-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pega/react-sdk-components",
-  "version": "0.23.20",
+  "version": "0.23.21",
   "description": "React SDK Infrastructure: bridge and components",
   "_filesComment": "During packing, npm ignores everything NOT in the files list",
   "files": [

--- a/packages/react-sdk-components/src/components/template/AppShell/AppShell.tsx
+++ b/packages/react-sdk-components/src/components/template/AppShell/AppShell.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
-import WssNavBar from '../WssNavBar';
 import { Utils } from '../../helpers/utils';
 import Avatar from '@material-ui/core/Avatar';
 import { NavContext } from '../../helpers/reactContextHelpers';
 import './AppShell.css';
 
-// AppShell can emit NavBar
+// AppShell can emit NavBar or WssNavBar
 import NavBar from '../../infra/NavBar';
+import WssNavBar from '../../template/WssNavBar';
 
 const useStyles = makeStyles(theme => ({
   root: {

--- a/packages/react-sdk-components/src/sdk-pega-component-map.js
+++ b/packages/react-sdk-components/src/sdk-pega-component-map.js
@@ -11,6 +11,8 @@ import Assignment from './components/infra/Assignment/Assignment';
 import AssignmentCard from './components/infra/AssignmentCard/AssignmentCard';
 import Attachment from './components/widget/Attachment';
 import AutoComplete from './components/field/AutoComplete';
+import Banner from './components/designSystemExtension/Banner';
+import BannerPage from './components/template/BannerPage';
 import CancelAlert from './components/field/CancelAlert';
 import CaseHistory from './components/widget/CaseHistory';
 import CaseSummary from './components/template/CaseSummary';
@@ -90,7 +92,7 @@ import WideNarrow from './components/template/WideNarrow/WideNarrow';
 import WideNarrowDetails from './components/template/WideNarrow/WideNarrowDetails';
 import WideNarrowForm from './components/template/WideNarrow/WideNarrowForm';
 import WideNarrowPage from './components/template/WideNarrow/WideNarrowPage';
-import BannerPage from './components/template/BannerPage';
+import WssNavBar from './components/template/WssNavBar/WssNavBar';
 
 // pegaSdkComponentMap is the JSON object where we'll store the components that are
 // the default implementations provided by the SDK. These will be used if there isn't
@@ -110,6 +112,8 @@ const pegaSdkComponentMap = {
   'AssignmentCard': AssignmentCard,
   'Attachment': Attachment,
   'AutoComplete': AutoComplete,
+  'Banner': Banner,
+  'BannerPage': BannerPage,
   'CancelAlert': CancelAlert,
   'CaseHistory': CaseHistory,
   'CaseSummary': CaseSummary,
@@ -189,7 +193,7 @@ const pegaSdkComponentMap = {
   'WideNarrowDetails': WideNarrowDetails,
   'WideNarrowForm': WideNarrowForm,
   'WideNarrowPage': WideNarrowPage,
-  'BannerPage': BannerPage
+  'WssNavBar': WssNavBar
 };
 
 export default pegaSdkComponentMap;

--- a/packages/react-sdk-overrides/package.json
+++ b/packages/react-sdk-overrides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pega/react-sdk-overrides",
-  "version": "0.23.20",
+  "version": "0.23.21",
   "description": "React SDK - Code for overriding components",
   "_filesComment": "During packing, npm ignores everything NOT in the files list",
   "files": [


### PR DESCRIPTION
Note some things to learn about adding new components and preparing for them to work as an override:

- Any added component should be added to the sdk-pega-component-map.js (and in alphabetical order, please)
-  To get the script that converts the source code to the proper overridable format, we need to avoid one-level of indirection import relative paths. For example: import WssNavBar from '../WssNavBar' should be done as import WssNavBar from '../../template/WssNavBar'

I'll keep fixing these kinds of things as needed but wanted to provide some more pointers on how to get everything to work the first time... Thanks!