### PR TITLE
Bug/spr/avoid empty creds

### DIFF
--- a/packages/react-sdk-components/src/components/helpers/authManager.js
+++ b/packages/react-sdk-components/src/components/helpers/authManager.js
@@ -139,7 +139,7 @@ const initOAuth = (bInit) => {
     if( 'silentTimeout' in sdkConfigAuth ) {
       authConfig.silentTimeout = sdkConfigAuth.silentTimeout;
     }
-    if( bNoInitialRedirect ) {
+    if( bNoInitialRedirect && sdkConfigAuth.mashupUserIdentifier && sdkConfigAuth.mashupPassword ) {
       authConfig.userIdentifier = sdkConfigAuth.mashupUserIdentifier;
       authConfig.password = sdkConfigAuth.mashupPassword;
     }


### PR DESCRIPTION
Don't bother passing userIdentifier or password to auth library unless both are set