### PR TITLE
Get components from map for infra components

### DIFF
--- a/packages/react-sdk-components/src/bridge/helpers/sdk_component_map.ts
+++ b/packages/react-sdk-components/src/bridge/helpers/sdk_component_map.ts
@@ -102,6 +102,27 @@ class ComponentMap {
 
 }
 
+export function getComponentFromMap(inComponentName: string): any {
+  let theComponentImplementation = null;
+  const theLocalComponent = SdkComponentMap.getLocalComponentMap()[inComponentName];
+  if (theLocalComponent !== undefined) {
+    // eslint-disable-next-line no-console
+    console.log(`Requested component found ${inComponentName}: Local`);
+    theComponentImplementation = theLocalComponent;
+  } else {
+    const thePegaProvidedComponent = SdkComponentMap.getPegaProvidedComponentMap()[inComponentName];
+    if (thePegaProvidedComponent !== undefined) {
+      // console.log(`Requested component found ${inComponentName}: Pega-provided`);
+      theComponentImplementation = thePegaProvidedComponent;
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(`Requested component has neither Local nor Pega-provided implementation: ${inComponentName}`);
+      theComponentImplementation = getComponentFromMap("ErrorBoundary");
+    }
+  }
+  return theComponentImplementation;
+}
+
 
 // Implement Factory function to allow async load
 //  See https://stackoverflow.com/questions/49905178/asynchronous-operations-in-constructor/49906064#49906064 for inspiration

--- a/packages/react-sdk-components/src/components/infra/Containers/FlowContainer/FlowContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/FlowContainer/FlowContainer.tsx
@@ -50,6 +50,10 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export default function FlowContainer(props) {
+    // Get the proper implementation (local or Pega-provided) for these components that are emitted below
+    const Assignment = getComponentFromMap("Assignment");
+    const ToDo = getComponentFromMap("Todo");   // NOTE: ConstellationJS Engine uses "Todo" and not "ToDo"!!!
+
   const pCoreConstants = PCore.getConstants();
   const { TODO } = pCoreConstants;
   const todo_headerText = 'To do';
@@ -86,9 +90,6 @@ export default function FlowContainer(props) {
 
   const classes = useStyles();
 
-  // Get the proper implementation (local or Pega-provided) for these components that are emitted below
-  const Assignment = getComponentFromMap("Assignment");
-  const ToDo = getComponentFromMap("Todo");   // NOTE: ConstellationJS Engine uses "Todo" and not "ToDo"!!!
 
   function initContainer() {
     const ourPConn = getPConnect();

--- a/packages/react-sdk-components/src/components/infra/Containers/FlowContainer/FlowContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/FlowContainer/FlowContainer.tsx
@@ -7,9 +7,6 @@ import { Card, CardHeader, Avatar, Typography } from '@material-ui/core';
 import { Utils } from '../../../helpers/utils';
 import { Alert } from '@material-ui/lab';
 
-import Assignment from '../../Assignment';
-import ToDo from '../../../widget/ToDo';
-
 import createPConnectComponent from '../../../../bridge/react_pconnect';
 import StoreContext from '../../../../bridge/Context/StoreContext';
 import DayjsUtils from '@date-io/dayjs';
@@ -17,6 +14,9 @@ import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 
 import { addContainerItem, getToDoAssignments, showBanner } from './helpers';
 import { isEmptyObject } from '../../../helpers/common-utils';
+// Need to get correct implementation from component map for Assignment and ToDo
+import { getComponentFromMap } from '../../../../bridge/helpers/sdk_component_map';
+
 
 // Remove this and use "real" PCore type once .d.ts is fixed (currently shows 3 errors)
 declare const PCore: any;
@@ -85,6 +85,10 @@ export default function FlowContainer(props) {
   const localeCategory = 'Messages';
 
   const classes = useStyles();
+
+  // Get the proper implementation (local or Pega-provided) for these components that are emitted below
+  const Assignment = getComponentFromMap("Assignment");
+  const ToDo = getComponentFromMap("Todo");   // NOTE: ConstellationJS Engine uses "Todo" and not "ToDo"!!!
 
   function initContainer() {
     const ourPConn = getPConnect();

--- a/packages/react-sdk-components/src/components/infra/Containers/FlowContainer/FlowContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/FlowContainer/FlowContainer.tsx
@@ -50,9 +50,9 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export default function FlowContainer(props) {
-    // Get the proper implementation (local or Pega-provided) for these components that are emitted below
-    const Assignment = getComponentFromMap("Assignment");
-    const ToDo = getComponentFromMap("Todo");   // NOTE: ConstellationJS Engine uses "Todo" and not "ToDo"!!!
+  // Get the proper implementation (local or Pega-provided) for these components that are emitted below
+  const Assignment = getComponentFromMap("Assignment");
+  const ToDo = getComponentFromMap("Todo");   // NOTE: ConstellationJS Engine uses "Todo" and not "ToDo"!!!
 
   const pCoreConstants = PCore.getConstants();
   const { TODO } = pCoreConstants;

--- a/packages/react-sdk-components/src/components/infra/Containers/ModalViewContainer/ModalViewContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/ModalViewContainer/ModalViewContainer.tsx
@@ -6,8 +6,8 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { makeStyles } from '@material-ui/core/styles';
 import createPConnectComponent from '../../../../bridge/react_pconnect';
-import Assignment from '../../Assignment';
-import CancelAlert from '../../../field/CancelAlert';
+// Need to get correct implementation from component map for Assignment and CancelAlert
+import { getComponentFromMap } from '../../../../bridge/helpers/sdk_component_map';
 import { getBanners } from '../../../helpers/case-utils';
 import { isEmptyObject } from '../../../helpers/common-utils';
 
@@ -93,6 +93,9 @@ const ModalViewContainer = props => {
 
   const localizedVal = PCore.getLocaleUtils().getLocaleValue;
   const localeCategory = 'Data Object';
+
+  const Assignment = getComponentFromMap("Assignment");
+  const CancelAlert = getComponentFromMap("CancelAlert");
 
   function showAlert(payload) {
     const { latestItem } = getKeyAndLatestItem(routingInfoRef.current, pConn);

--- a/packages/react-sdk-components/src/components/infra/Containers/ModalViewContainer/ModalViewContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/ModalViewContainer/ModalViewContainer.tsx
@@ -71,6 +71,10 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const ModalViewContainer = props => {
+  // Get the proper implementation (local or Pega-provided) for these components that are emitted below
+  const Assignment = getComponentFromMap("Assignment");
+  const CancelAlert = getComponentFromMap("CancelAlert");
+
   const classes = useStyles();
 
   const routingInfoRef = useRef({});
@@ -94,8 +98,6 @@ const ModalViewContainer = props => {
   const localizedVal = PCore.getLocaleUtils().getLocaleValue;
   const localeCategory = 'Data Object';
 
-  const Assignment = getComponentFromMap("Assignment");
-  const CancelAlert = getComponentFromMap("CancelAlert");
 
   function showAlert(payload) {
     const { latestItem } = getKeyAndLatestItem(routingInfoRef.current, pConn);

--- a/packages/react-sdk-components/src/components/infra/View/View.tsx
+++ b/packages/react-sdk-components/src/components/infra/View/View.tsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 // import { FieldGroup } from "@pega/cosmos-react-core";
 // import { LazyMap as LazyComponentMap } from "../../components_map";
 
-import { SdkComponentMap } from '../../../bridge/helpers/sdk_component_map';
-import ErrorBoundary from '../ErrorBoundary';
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 
 import { getAllFields } from '../../helpers/template-utils';
 
@@ -57,38 +56,12 @@ export default function View(props) {
   //  JA - React SDK not using LazyComponentMap yet
   if (template /* && LazyComponentMap[template] */) {
     // const ViewTemplate = LazyComponentMap[template];
-    let ViewTemplate: any;
+    const ViewTemplate: any = getComponentFromMap(template);
 
-    if (SdkComponentMap) {
-      // This is the node_modules version of react_pconnect!
-      const theLocalComponent = SdkComponentMap.getLocalComponentMap()[template];
-      if (theLocalComponent !== undefined) {
-        // eslint-disable-next-line no-console
-        console.log(`View component found ${template}: Local`);
-        ViewTemplate = theLocalComponent;
-      } else {
-        const thePegaProvidedComponent = SdkComponentMap.getPegaProvidedComponentMap()[template];
-        if (thePegaProvidedComponent !== undefined) {
-          // console.log(`View component found ${template}: Pega-provided`);
-          ViewTemplate = thePegaProvidedComponent;
-        } else {
-          // eslint-disable-next-line no-console
-          console.error(`View component can't find template type ${template}`);
-          ViewTemplate = ErrorBoundary;
-        }
-      }
-
-      if (template === 'ListView') {
-        // special case for ListView - add in a prop
-        const bInForm = true;
-        props = { ...props, bInForm };
-      }
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn(`View: SdkComponentMap expected but not found.`);
-
-      // eslint-disable-next-line no-console
-      console.error(`View: Trying to render an unknown template: ${template}`);
+    if (template === 'ListView') {
+      // special case for ListView - add in a prop
+      const bInForm = true;
+      props = { ...props, bInForm };
     }
 
     // for debugging/investigation


### PR DESCRIPTION
This fixes the case where some infra components (that are **not** exposed for potential overriding) are rendering 
components that **can** be overridden without checking the component map to see if there is a local implementation.

Added a new helper function: getComponentFromMap and now use that in FlowContainer and ModalViewContainer to address that problem. Also, updated View component to use the new function, too.