### PR TITLE
For symmetry with react-sdk, no webpack load for .d.ts or .map files

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "json5": ">=1.0.2",
     "monocart-reporter": "^1.6.17",
     "npm-run-all": "^4.1.5",
+    "null-loader": "^4.0.1",
     "prettier": "^2.8.1",
     "prop-types": "^15.7.2",
     "replace-in-file": "^6.3.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -191,6 +191,14 @@ module.exports = (env, argv) => {
               /node_modules/,
               /(ngfactory|ngstyle)\.js/
             ]
+        },
+        {
+          test: /\.(d.ts)$/,    /* latest react-sdk-components needs to ignore compiling .d.ts and .map files */
+          loader: 'null-loader',
+        },
+        {
+          test: /\.(map)$/,    /* latest react-sdk-components needs to ignore compiling .d.ts and .map files */
+          loader: 'null-loader',
         }
       ]
     },


### PR DESCRIPTION
This may not matter here but keeping aligned with react-sdk PR 378