### PR TITLE
Attempt to address AuthManager typings

### DIFF
--- a/packages/react-sdk-components/src/components/helpers/authManager.ts
+++ b/packages/react-sdk-components/src/components/helpers/authManager.ts
@@ -416,7 +416,7 @@ class AuthManager {
           resolve(this.#pegaAuth);
         });
       } else {
-        let idNextCheck:number|null = null;
+        let idNextCheck: ReturnType<typeof setInterval>;
         const fnCheckForAuthMgr = () => {
           if( !this.initInProgress ) {
             if( idNextCheck ) {
@@ -601,7 +601,8 @@ class AuthManager {
       const appAlias = serverConfig.appAlias;
       const appAliasPath = appAlias ? `/app/${appAlias}` : '';
       const arExcludedPortals = serverConfig['excludePortals'];
-      const headers:HeadersInit = {
+      // eslint-disable-next-line no-undef
+      const headers: HeadersInit = {
         Authorization: this.#authHeader===null ? '': this.#authHeader,
         'Content-Type': 'application/json'
       };


### PR DESCRIPTION
When the new typings info was merged, the typings in the (also updated) authManager.ts aren't recognized as correct. So, this is an attempt to fix those typings. (This code works but I'm not sure why the HeadersInit type isn't recognized (other than that it doesn't seem to be in node_modules/@types though VS Code finds it via its own path.)