### PR TITLE
Use latest 8.8 - patch/2.3 Typedefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@pega/configs": "^0.4.0",
     "@pega/cspell-config": "^0.4.0",
     "@pega/eslint-config": "^0.4.0",
-    "@pega/pcore-pconnect-typedefs": "file:pega-pcore-pconnect-typedefs-8.8.3-dev-1-20230911.tgz",
+    "@pega/pcore-pconnect-typedefs": "file:pega-pcore-pconnect-typedefs-1.0.0-patch.2.3-20230925.tgz",
     "@pega/prettier-config": "^0.4.0",
     "@pega/stylelint-config": "^0.4.0",
     "@pega/tsconfig": "^0.4.0",


### PR DESCRIPTION
Setting up master for testing against 8.8. **Once that's settled**, I'll be branching master off to release/8.8.12 for future work and master will be set up to be associated with 23.1.10 release.