### PR TITLE
Fix issue with subsequent authorize not having the session_index query arg

### DIFF
--- a/packages/react-sdk-components/src/components/helpers/auth.js
+++ b/packages/react-sdk-components/src/components/helpers/auth.js
@@ -132,13 +132,15 @@ class PegaAuth {
         redirectUri,
         authorizeUri,
         authService,
-        sessionIndex,
         appAlias,
         userIdentifier,
         password,
         noPKCE,
         isolationId
       } = this.#config;
+      const {
+        sessionIndex,
+      } = this.#dynState;
       const bInfinity = serverType === 'infinity';
 
       if (!noPKCE) {
@@ -556,7 +558,6 @@ class PegaAuth {
         clientSecret,
         tokenUri,
         grantType,
-        sessionIndex,
         customTokenParams,
         userIdentifier,
         password,
@@ -564,6 +565,7 @@ class PegaAuth {
       } = this.#config;
 
       const {
+        sessionIndex,
         acRedirectUri,
         codeVerifier
       } = this.#dynState;


### PR DESCRIPTION
(On subsequent full re auth or on browser reload)

Clean up regression with locking introduced with PR #178 