### PR TITLE
Get types working with newly published version; align fixes with that…

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@pega/configs": "^0.4.0",
     "@pega/cspell-config": "^0.4.0",
     "@pega/eslint-config": "^0.4.0",
-    "@pega/pcore-pconnect-typedefs": "8.23.0-dev-2",
+    "@pega/pcore-pconnect-typedefs": "8.23.0-dev-3",
     "@pega/prettier-config": "^0.4.0",
     "@pega/stylelint-config": "^0.4.0",
     "@pega/tsconfig": "^0.4.0",

--- a/packages/react-sdk-components/src/components/field/Checkbox/Checkbox.tsx
+++ b/packages/react-sdk-components/src/components/field/Checkbox/Checkbox.tsx
@@ -8,34 +8,36 @@ import {
 } from '@material-ui/core';
 import handleEvent from '../../helpers/event-utils';
 import FieldValueList from '../../designSystemExtension/FieldValueList';
-import type { PConnProps } from '../../../types/PConnProps';
+// import type { PConnProps } from '../../../types/PConnProps';
 
 // Checkbox passes in 'value' as a boolean. So can't use the default
 //  PConnFieldProps since it expects value to be a string.
-interface CheckboxProps extends PConnProps {
-  // If any, enter additional props that only exist on Checkbox here
-  // Everything from PConnFieldProps except value and change type of value to boolean
+// But can't use CheckBoxProps until getValidationApi() knows about validate method
+//  Currently just thinks that returns an "object"
+// interface CheckboxProps extends PConnProps {
+//   // If any, enter additional props that only exist on Checkbox here
+//   // Everything from PConnFieldProps except value and change type of value to boolean
 
-  value?: boolean,
-  label: string,
-  required: boolean,
-  disabled: boolean,
-  validatemessage: string,
-  status?: string,
-  // eslint-disable-next-line react/no-unused-prop-types
-  onChange: any,
-  // eslint-disable-next-line react/no-unused-prop-types
-  onBlur?: any,
-  readOnly: boolean,
-  testId: string,
-  helperText: string,
-  displayMode?: string,
-  hideLabel: boolean,
-  // eslint-disable-next-line react/no-unused-prop-types
-  placeholder?: string
-}
+//   value?: boolean,
+//   label: string,
+//   required: boolean,
+//   disabled: boolean,
+//   validatemessage: string,
+//   status?: string,
+//   // eslint-disable-next-line react/no-unused-prop-types
+//   onChange: any,
+//   // eslint-disable-next-line react/no-unused-prop-types
+//   onBlur?: any,
+//   readOnly: boolean,
+//   testId: string,
+//   helperText: string,
+//   displayMode?: string,
+//   hideLabel: boolean,
+//   // eslint-disable-next-line react/no-unused-prop-types
+//   placeholder?: string
+// }
 
-export default function CheckboxComponent(props: CheckboxProps) {
+export default function CheckboxComponent(props /* : CheckboxProps */) {
   const {
     getPConnect,
     label,

--- a/packages/react-sdk-components/src/components/helpers/authManager.ts
+++ b/packages/react-sdk-components/src/components/helpers/authManager.ts
@@ -591,7 +591,7 @@ class AuthManager {
       const appAlias = serverConfig.appAlias;
       const appAliasPath = appAlias ? `/app/${appAlias}` : '';
       const arExcludedPortals = serverConfig['excludePortals'];
-      // eslint-disable-next-line no-undef
+
       const headers: HeadersInit = {
         Authorization: this.#authHeader===null ? '': this.#authHeader,
         'Content-Type': 'application/json'

--- a/packages/react-sdk-components/src/components/infra/Containers/ModalViewContainer/ModalViewContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/ModalViewContainer/ModalViewContainer.tsx
@@ -10,14 +10,16 @@ import { getComponentFromMap } from '../../../../bridge/helpers/sdk_component_ma
 import { getBanners } from '../../../helpers/case-utils';
 import { isEmptyObject } from '../../../helpers/common-utils';
 
-import type { PConnProps } from '../../../../types/PConnProps';
+// import type { PConnProps } from '../../../../types/PConnProps';
 
-interface ModalViewContainerProps extends PConnProps {
-  // If any, enter additional props that only exist on this component
-  loadingInfo?: string,
-  routingInfo?: any,
-  pageMessages?: Array<string>
-}
+// Can't use ModalViewContainerProps until getContainerManager() knows about initializeContainers
+//  Currently just expects "object"
+// interface ModalViewContainerProps extends PConnProps {
+//   // If any, enter additional props that only exist on this component
+//   loadingInfo?: string,
+//   routingInfo?: any,
+//   pageMessages?: Array<string>
+// }
 
 
 // Remove this and use "real" PCore type once .d.ts is fixed (currently shows 8 errors)
@@ -79,7 +81,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-export default function ModalViewContainer(props: ModalViewContainerProps) {
+export default function ModalViewContainer(props /* : ModalViewContainerProps */) {
   // Get the proper implementation (local or Pega-provided) for these components that are emitted below
   const Assignment = getComponentFromMap("Assignment");
   const CancelAlert = getComponentFromMap("CancelAlert");

--- a/packages/react-sdk-components/src/components/template/PromotedFilters/PromotedFilters.tsx
+++ b/packages/react-sdk-components/src/components/template/PromotedFilters/PromotedFilters.tsx
@@ -6,16 +6,18 @@ import ListView from '../ListView';
 import { isEmptyObject } from '../../helpers/common-utils';
 import './PromotedFilters.css';
 
-import type { PConnProps } from '../../../types/PConnProps';
+// import type { PConnProps } from '../../../types/PConnProps';
 
-interface PromotedFilterProps extends PConnProps {
-  // If any, enter additional props that only exist on this component
-  viewName: string,
-  filters: Array<any>,
-  listViewProps: any,
-  pageClass: string,
-  parameters?: object
-}
+// Can't use PromotedFilterProps until getContainerManager() knows about addTransientItem
+//  Currently just expects "object"
+// interface PromotedFilterProps extends PConnProps {
+//   // If any, enter additional props that only exist on this component
+//   viewName: string,
+//   filters: Array<any>,
+//   listViewProps: any,
+//   pageClass: string,
+//   parameters?: object
+// }
 
 
 const localeCategory = 'SimpleTable';
@@ -65,7 +67,7 @@ function isValidInput(input) {
   return Object.values(input).findIndex((v) => v) >= 0;
 }
 
-export default function PromotedFilters(props: PromotedFilterProps) {
+export default function PromotedFilters(props /* : PromotedFilterProps */) {
   const localizedVal = PCore.getLocaleUtils().getLocaleValue;
   const { getPConnect, viewName, filters, listViewProps, pageClass, parameters } = props;
   const [initTable, setInitTable] = useState(false);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "sourceMap": true,
     "module": "es2020",
     "target": "es2020",
-    "lib": [ "es2021" ],
+    "lib": [ "es2021", "dom" ],
     "moduleResolution": "node",
     "jsx": "react",     // May be different options for this with newer versions of React
     "allowJs": true,    // must be false for @pega/pcore-pconnect-typedefs
@@ -32,7 +32,8 @@
     // Declare all ambient type declarations here for VSCode.
     // Override with only specific types for other configurations.
 
-    "typeRoots": ["node_modules/@types", "typings"],
+    "typeRoots": ["node_modules/@types", "node_modules/@pega"],
+    "types": [ "jest", "@testing-library/jest-dom", "pcore-pconnect-typedefs" ],
 
     "noEmit": false,    // JEA - was false
     "incremental": true,


### PR DESCRIPTION
… version

Note: important changes in tsconfig.json to work with new style of finding/using typedefs. (No longer copied to node_modules/@types since that wasn't reliable.)