### PR TITLE
Get types working with newly published version

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@pega/configs": "^0.4.0",
     "@pega/cspell-config": "^0.4.0",
     "@pega/eslint-config": "^0.4.0",
-    "@pega/pcore-pconnect-typedefs": "file:pega-pcore-pconnect-typedefs-1.0.0-patch.2.3-20230925.tgz",
+    "@pega/pcore-pconnect-typedefs": "8.8.3-dev-0",
     "@pega/prettier-config": "^0.4.0",
     "@pega/stylelint-config": "^0.4.0",
     "@pega/tsconfig": "^0.4.0",

--- a/packages/react-sdk-components/src/components/helpers/authManager.ts
+++ b/packages/react-sdk-components/src/components/helpers/authManager.ts
@@ -591,7 +591,7 @@ class AuthManager {
       const appAlias = serverConfig.appAlias;
       const appAliasPath = appAlias ? `/app/${appAlias}` : '';
       const arExcludedPortals = serverConfig['excludePortals'];
-      // eslint-disable-next-line no-undef
+
       const headers: HeadersInit = {
         Authorization: this.#authHeader===null ? '': this.#authHeader,
         'Content-Type': 'application/json'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "sourceMap": true,
     "module": "es2020",
     "target": "es2020",
-    "lib": [ "es2021" ],
+    "lib": [ "es2021", "dom" ],
     "moduleResolution": "node",
     "jsx": "react",     // May be different options for this with newer versions of React
     "allowJs": true,    // must be false for @pega/pcore-pconnect-typedefs
@@ -32,7 +32,8 @@
     // Declare all ambient type declarations here for VSCode.
     // Override with only specific types for other configurations.
 
-    "typeRoots": ["node_modules/@types", "typings"],
+    "typeRoots": ["node_modules/@types", "node_modules/@pega"],
+    "types": [ "jest", "@testing-library/jest-dom", "pcore-pconnect-typedefs" ],
 
     "noEmit": false,    // JEA - was false
     "incremental": true,


### PR DESCRIPTION
Note: important changes in tsconfig.json to work with new style of finding/using typedefs. (No longer copied to node_modules/https://github.com/types since that wasn't reliable.)