### PR TITLE
Update to use "prod" typedefs for 23.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@pega/configs": "^0.4.0",
     "@pega/cspell-config": "^0.4.0",
     "@pega/eslint-config": "^0.4.0",
-    "@pega/pcore-pconnect-typedefs": "8.23.0-dev-3",
+    "@pega/pcore-pconnect-typedefs": "2.0.0",
     "@pega/prettier-config": "^0.4.0",
     "@pega/stylelint-config": "^0.4.0",
     "@pega/tsconfig": "^0.4.0",


### PR DESCRIPTION
The 3 portal test fails. A known problem to be fixed soon. Unrelated to this change.