### PR TITLE
Add icon for pi-home-solid

### DIFF
--- a/packages/react-sdk-components/src/components/infra/NavBar/NavBar.tsx
+++ b/packages/react-sdk-components/src/components/infra/NavBar/NavBar.tsx
@@ -49,7 +49,8 @@ interface NavBarProps extends PConnProps {
 
 const iconMap = {
   'pi pi-headline': <HomeOutlinedIcon fontSize='large' />,
-  'pi pi-flag-solid': <FlagOutlinedIcon fontSize='large' />
+  'pi pi-flag-solid': <FlagOutlinedIcon fontSize='large' />,
+  'pi pi-home-solid': <HomeOutlinedIcon fontSize='large' />
 };
 
 const drawerWidth = 300;


### PR DESCRIPTION
Some apps send 'pi-home-solid' for the "Home" icon