### PR TITLE
Add "optional" args to get typedefs to work for createComponent

### DIFF
--- a/packages/react-sdk-components/src/components/field/ScalarList/ScalarList.tsx
+++ b/packages/react-sdk-components/src/components/field/ScalarList/ScalarList.tsx
@@ -48,7 +48,7 @@ export default function ScalarList(props: ScalarListProps) {
         readOnly: 'true'
       }
     },
-    '','', {}); // 2nd, 3rd, and 4th args empty string/object until typedef marked correctly as optional
+    null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;
   });
 
   if (['LABELS_LEFT', 'STACKED_LARGE_VAL', 'DISPLAY_ONLY'].includes(displayMode)) {

--- a/packages/react-sdk-components/src/components/infra/Containers/ViewContainer/ViewContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/ViewContainer/ViewContainer.tsx
@@ -15,24 +15,6 @@ interface ViewContainerProps extends PConnProps {
   limit?: number
 }
 
-// ViewContainer.defaultProps = {
-//   getPConnect: null,
-//   name: "",
-//   loadingInfo: false,
-//   routingInfo: null,
-//   mode: "single",
-//   limit: 16
-// };
-
-// ViewContainer.propTypes = {
-//   getPConnect: PropTypes.func,
-//   name: PropTypes.string,
-//   loadingInfo: PropTypes.bool,
-//   routingInfo: PropTypes.objectOf(PropTypes.any),
-//   mode: PropTypes.string,
-//   limit: PropTypes.number
-// };
-
 
 // ViewContainer can emit View
 // import View from '../View';

--- a/packages/react-sdk-components/src/components/infra/DashboardFilter/DashboardFilter.tsx
+++ b/packages/react-sdk-components/src/components/infra/DashboardFilter/DashboardFilter.tsx
@@ -12,20 +12,19 @@ import DatePicker from 'react-datepicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
 
-// import type { PConnProps } from '../../../types/PConnProps';
+import type { PConnProps } from '../../../types/PConnProps';
 
-// Can't use DashboardFilter props until createComponent typedefs properly allow optional args
-// interface DashboardFilterProps extends PConnProps {
-//   // If any, enter additional props that only exist on this component
-//   children?: Array<any>,
-//   name: string,
-//   filterProp: string,
-//   type?: string,
-//   metadata?: any
-// }
+interface DashboardFilterProps extends PConnProps {
+  // If any, enter additional props that only exist on this component
+  children?: Array<any>,
+  name: string,
+  filterProp: string,
+  type?: string,
+  metadata?: any
+}
 
 
-export default function DashboardFilter(props /* : DashboardFilterProps */) {
+export default function DashboardFilter(props: DashboardFilterProps) {
   const { children = [], name, filterProp, type = '', metadata = null, getPConnect } = props;
   const { current: filterId } = useRef(uuidv4());
 
@@ -109,7 +108,8 @@ export default function DashboardFilter(props /* : DashboardFilterProps */) {
     metadata.config.onRecordChange = e => {
       fireFilterChange(e.id);
     };
-    return getPConnect().createComponent(metadata);
+    return getPConnect().createComponent(metadata,
+      null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;
   };
 
   const onChange = dates => {

--- a/packages/react-sdk-components/src/components/infra/DashboardFilter/filterUtils.tsx
+++ b/packages/react-sdk-components/src/components/infra/DashboardFilter/filterUtils.tsx
@@ -91,7 +91,7 @@ export const createFilterComponent = (getPConnect, filterMeta, index) => {
       metadata={filterMeta}
       type={filterMeta.type}
     >
-      {getPConnect().createComponent(filterMeta)}
+      {getPConnect().createComponent(filterMeta, '','', {})}
     </DashboardFilter>
   );
 };

--- a/packages/react-sdk-components/src/components/infra/Reference/Reference.tsx
+++ b/packages/react-sdk-components/src/components/infra/Reference/Reference.tsx
@@ -10,21 +10,6 @@ interface ReferenceProps extends PConnProps {
   displayMode?: string
 }
 
-// Reference.defaultProps = {
-//   visibility: true,
-//   context: null,
-//   readOnly: false,
-//   displayMode: null
-// };
-
-// Reference.propTypes = {
-//   getPConnect: PropTypes.func.isRequired,
-//   visibility: PropTypes.bool,
-//   context: PropTypes.string,
-//   readOnly: PropTypes.bool,
-//   displayMode: PropTypes.string
-// };
-
 
 export default function Reference(props: ReferenceProps) {
   const { visibility = true, context = '', getPConnect, readOnly = false, displayMode = '' } = props;

--- a/packages/react-sdk-components/src/components/template/CaseView/CaseView.tsx
+++ b/packages/react-sdk-components/src/components/template/CaseView/CaseView.tsx
@@ -60,10 +60,12 @@ const useStyles = makeStyles(theme => ({
 export default function CaseView(props: CaseViewProps) {
   const {
     getPConnect,
-    icon,
+    icon = '',
     header,
     subheader,
-    children,
+    children = [],
+    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+    showIconInHeader = true,
     caseInfo: {
       availableActions = [],
       availableProcesses = [],
@@ -288,11 +290,3 @@ export default function CaseView(props: CaseViewProps) {
 
   return getContainerContents();
 }
-
-CaseView.defaultProps = {
-  icon: '',
-  children: [],
-  caseInfo: {},
-  showIconInHeader: true,
-  getPConnect: null
-};

--- a/packages/react-sdk-components/src/components/template/DataReference/DataReference.tsx
+++ b/packages/react-sdk-components/src/components/template/DataReference/DataReference.tsx
@@ -249,7 +249,8 @@ export default function DataReference(props /* : DataReferenceProps */) {
           hideLabel,
           onRecordChange: handleSelection
         }
-      });
+      },
+      null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;);
     }
   }, [
     firstChildMeta.config?.datasource?.source,
@@ -279,31 +280,3 @@ export default function DataReference(props /* : DataReferenceProps */) {
     </div>
   );
 }
-
-// DataReference.defaultProps = {
-//   label: undefined,
-//   showLabel: undefined,
-//   displayMode: undefined,
-//   allowAndPersistChangesInReviewMode: false,
-//   referenceType: '',
-//   selectionMode: '',
-//   displayAs: '',
-//   ruleClass: '',
-//   parameters: undefined,
-//   hideLabel: false
-// };
-
-// DataReference.propTypes = {
-//   children: PropTypes.arrayOf(PropTypes.node).isRequired,
-//   getPConnect: PropTypes.func.isRequired,
-//   label: PropTypes.string,
-//   showLabel: PropTypes.func,
-//   displayMode: PropTypes.string,
-//   allowAndPersistChangesInReviewMode: PropTypes.bool,
-//   referenceType: PropTypes.string,
-//   selectionMode: PropTypes.string,
-//   displayAs: PropTypes.string,
-//   ruleClass: PropTypes.string,
-//   parameters: PropTypes.arrayOf(PropTypes.string), // need to fix
-//   hideLabel: PropTypes.bool
-// };

--- a/packages/react-sdk-components/src/components/template/Details/Details/Details.tsx
+++ b/packages/react-sdk-components/src/components/template/Details/Details/Details.tsx
@@ -5,8 +5,7 @@ import FieldGroup from '../../../designSystemExtension/FieldGroup';
 // import type { PConnProps } from '../../../../types/PConnProps';
 
 
-// Can't use PConnProps until getPConnect().getChildren() types are ok
-//  and createComponent types are ok
+// Can't use PConnProps until getPConnect().getChildren() type is ok
 // interface DetailsProps extends PConnProps {
 //   // If any, enter additional props that only exist on this component
 // }
@@ -45,7 +44,8 @@ export default function Details(props /* : DetailsProps */) {
         field.config.displayAsStatus = true;
       }
 
-      return getPConnect().createComponent(field);
+      return getPConnect().createComponent(field,
+        '','', {}); // 2nd, 3rd, and 4th args empty string/object until typedef marked correctly as optional;);
     });
   }
 

--- a/packages/react-sdk-components/src/components/template/Details/DetailsThreeColumn/DetailsThreeColumn.tsx
+++ b/packages/react-sdk-components/src/components/template/Details/DetailsThreeColumn/DetailsThreeColumn.tsx
@@ -4,8 +4,7 @@ import createPConnectComponent from '../../../../bridge/react_pconnect';
 import FieldGroup from '../../../designSystemExtension/FieldGroup';
 // import type { PConnProps } from '../../../../types/PConnProps';
 
-// Can't use PConnProps until getPConnect().getChildren() types are ok
-//  and createComponent types are ok
+// Can't use PConnProps until getPConnect().getChildren() type is ok
 // interface DetailsThreeColumnProps extends PConnProps {
 //   // If any, enter additional props that only exist on this component
 //   showLabel: boolean,
@@ -47,7 +46,8 @@ export default function DetailsThreeColumn(props /* : DetailsThreeColumnProps */
         field.config.displayAsStatus = true;
       }
 
-      return getPConnect().createComponent(field);
+      return getPConnect().createComponent(field,
+        null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;
     });
   }
 

--- a/packages/react-sdk-components/src/components/template/Details/DetailsTwoColumn/DetailsTwoColumn.tsx
+++ b/packages/react-sdk-components/src/components/template/Details/DetailsTwoColumn/DetailsTwoColumn.tsx
@@ -5,8 +5,7 @@ import FieldGroup from '../../../designSystemExtension/FieldGroup';
 // import type { PConnProps } from '../../../../types/PConnProps';
 
 
-// Can't use PConnProps until getPConnect().getChildren() types are ok
-//  and createComponent types are ok
+// Can't use PConnProps until getPConnect().getChildren() type is ok
 // interface DetailsTwoColumnProps extends PConnProps {
 //   // If any, enter additional props that only exist on this component
 //   showLabel: boolean,
@@ -48,7 +47,8 @@ export default function DetailsTwoColumn(props /* : DetailsTwoColumnProps */) {
         field.config.displayAsStatus = true;
       }
 
-      return getPConnect().createComponent(field);
+      return getPConnect().createComponent(field,
+        null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;
     });
   }
 

--- a/packages/react-sdk-components/src/components/template/MultiReferenceReadOnly/MultiReferenceReadOnly.tsx
+++ b/packages/react-sdk-components/src/components/template/MultiReferenceReadOnly/MultiReferenceReadOnly.tsx
@@ -1,15 +1,14 @@
 import React from "react";
-// import type { PConnProps } from '../../../types/PConnProps';
+import type { PConnProps } from '../../../types/PConnProps';
 
-// Can't use PConn props until proper props for createComponent in typedefs
-// interface MultiReferenceReadOnlyProps extends PConnProps {
-//   config: { referenceList: any, readonlyContextList: any },
-//   label: string,
-//   hideLabel: boolean
-// }
+interface MultiReferenceReadOnlyProps extends PConnProps {
+  config: { referenceList: any, readonlyContextList: any },
+  label: string,
+  hideLabel: boolean
+}
 
 
-export default function MultiReferenceReadOnly(props /* : MultiReferenceReadOnlyProps */) {
+export default function MultiReferenceReadOnly(props: MultiReferenceReadOnlyProps) {
   const { getPConnect, label = '', hideLabel = false, config } = props;
   const { referenceList, readonlyContextList } = config;
 
@@ -29,7 +28,8 @@ export default function MultiReferenceReadOnly(props /* : MultiReferenceReadOnly
       label,
       hideLabel
     }
-  });
+  },
+  null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;
 
    return (
     <React.Fragment>{component}</React.Fragment>

--- a/packages/react-sdk-components/src/components/template/NarrowWide/NarrowWideDetails/NarrowWideDetails.tsx
+++ b/packages/react-sdk-components/src/components/template/NarrowWide/NarrowWideDetails/NarrowWideDetails.tsx
@@ -5,8 +5,7 @@ import createPConnectComponent from '../../../../bridge/react_pconnect';
 import FieldGroup from '../../../designSystemExtension/FieldGroup';
 // import type { PConnProps } from '../../../../types/PConnProps';
 
-// Can't use PConnProps until getPConnect().getChildren() types are ok
-//  and createComponent types are ok
+// Can't use PConnProps until getPConnect().getChildren() type is ok
 // interface NarrowWideDetailsProps extends PConnProps {
 //   // If any, enter additional props that only exist on this component
 //   showLabel?: boolean,
@@ -50,7 +49,8 @@ export default function NarrowWideDetails(props /* : NarrowWideDetailsProps */) 
         field.config.displayAsStatus = true;
       }
 
-      return getPConnect().createComponent(field);
+      return getPConnect().createComponent(field,
+        null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;
     });
   }
 

--- a/packages/react-sdk-components/src/components/template/SingleReferenceReadOnly/SingleReferenceReadOnly.tsx
+++ b/packages/react-sdk-components/src/components/template/SingleReferenceReadOnly/SingleReferenceReadOnly.tsx
@@ -1,21 +1,22 @@
-// import type { PConnProps } from '../../../types/PConnProps';
+import React from "react";
+import type { PConnProps } from '../../../types/PConnProps';
 
 // Need to fix an error noted in comment below before typedefs will work correctly
-// interface SingleReferenceReadOnlyProps extends PConnProps {
-//   // If any, enter additional props that only exist on this component
-//   config: any,
-//   displayAs?: string,
-//   ruleClass?: string,
-//   label?: string,
-//   displayMode?: string,
-//   type: string,
-//   referenceType?: string,
-//   hideLabel?: boolean,
-//   dataRelationshipContext?: string
-// }
+interface SingleReferenceReadOnlyProps extends PConnProps {
+  // If any, enter additional props that only exist on this component
+  config: any,
+  displayAs?: string,
+  ruleClass?: string,
+  label?: string,
+  displayMode?: string,
+  type: string,
+  referenceType?: string,
+  hideLabel?: boolean,
+  dataRelationshipContext?: string
+}
 
 
-export default function SingleReferenceReadOnly(props /* : SingleReferenceReadOnlyProps */) {
+export default function SingleReferenceReadOnly(props: SingleReferenceReadOnlyProps) {
   const {
     getPConnect,
     displayAs = '',
@@ -44,8 +45,7 @@ export default function SingleReferenceReadOnly(props /* : SingleReferenceReadOn
     };
   }
 
-  // Need to correct typedefs for createComponent for typedefs to work in this file
-  return getPConnect().createComponent({
+  const component = getPConnect().createComponent({
     type: 'SemanticLink',
     config: {
       ...config,
@@ -55,5 +55,10 @@ export default function SingleReferenceReadOnly(props /* : SingleReferenceReadOn
       hideLabel,
       dataRelationshipContext
     }
-  });
+  },
+  null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;
+
+  return (
+    <React.Fragment>{component}</React.Fragment>
+  )
 }

--- a/packages/react-sdk-components/src/components/template/WideNarrow/WideNarrowDetails/WideNarrowDetails.tsx
+++ b/packages/react-sdk-components/src/components/template/WideNarrow/WideNarrowDetails/WideNarrowDetails.tsx
@@ -5,7 +5,7 @@ import createPConnectComponent from '../../../../bridge/react_pconnect';
 import FieldGroup from '../../../designSystemExtension/FieldGroup';
 // import type { PConnProps } from '../../../../types/PConnProps';
 
-// Can't use PConnProps until createComponent types are ok
+// Can't use PConnProps until getPConnect.getChildren() type is ok
 // interface WideNarrowDetailsProps extends PConnProps {
 //   // If any, enter additional props that only exist on this component
 //   showLabel?: boolean,
@@ -43,7 +43,7 @@ export default function WideNarrowDetails(props /* : WideNarrowDetailsProps */) 
   // Set up highlighted data to pass in return if is set to show, need raw metadata to pass to createComponent
   let highlightedDataArr = [];
   if (showHighlightedData) {
-    const { highlightedData = [] } = getPConnect().getRawMetadata().config;
+    const { highlightedData = [] } = getPConnect().getRawMetadata()["config"];
     highlightedDataArr = highlightedData.map(field => {
       field.config.displayMode = 'STACKED_LARGE_VAL';
 
@@ -53,7 +53,8 @@ export default function WideNarrowDetails(props /* : WideNarrowDetailsProps */) 
         field.config.displayAsStatus = true;
       }
 
-      return getPConnect().createComponent(field);
+      return getPConnect().createComponent(field,
+        null, null, {}); // 2nd, 3rd, and 4th args empty string/object/null until typedef marked correctly as optional;
     });
   }
 


### PR DESCRIPTION
The current version of the typedefs don't mark some args to createComponent as optional (even though they act as optional). So, we can re-enable some typedefs by adding in the optional arguments - typically, "null, null, {}