### PR TITLE
Initial set of replacing import with getComponentFromMap

### DIFF
--- a/packages/react-sdk-components/src/components/designSystemExtension/CaseSummaryFields/CaseSummaryFields.tsx
+++ b/packages/react-sdk-components/src/components/designSystemExtension/CaseSummaryFields/CaseSummaryFields.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import isDeepEqual from 'fast-deep-equal/react';
-
+import isDeepEqual from 'fast-deep-equal/react';=
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
-import Operator from '../Operator';
 import { getDateFormatInfo } from '../../helpers/date-format-utils';
 import { getCurrencyOptions } from '../../field/Currency/currency-utils';
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 
 import './CaseSummaryFields.css';
 
@@ -21,7 +20,10 @@ interface CaseSummaryFieldsProps{
 }
 
 
-export default function CaseSummaryFields(props:CaseSummaryFieldsProps) {
+export default function CaseSummaryFields(props: CaseSummaryFieldsProps) {
+  // Get emitted components from map (so we can get any override that may exist)
+  const Operator = getComponentFromMap("Operator");
+
   const { status, showStatus, theFields } = props;
 
   const [theFieldsToRender, setFieldsToRender] = useState([]);

--- a/packages/react-sdk-components/src/components/designSystemExtension/CaseSummaryFields/CaseSummaryFields.tsx
+++ b/packages/react-sdk-components/src/components/designSystemExtension/CaseSummaryFields/CaseSummaryFields.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import isDeepEqual from 'fast-deep-equal/react';=
+import isDeepEqual from 'fast-deep-equal/react'
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import { getDateFormatInfo } from '../../helpers/date-format-utils';

--- a/packages/react-sdk-components/src/components/designSystemExtension/CaseSummaryFields/CaseSummaryFields.tsx
+++ b/packages/react-sdk-components/src/components/designSystemExtension/CaseSummaryFields/CaseSummaryFields.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import isDeepEqual from 'fast-deep-equal/react'
+import isDeepEqual from 'fast-deep-equal/react';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import { getDateFormatInfo } from '../../helpers/date-format-utils';

--- a/packages/react-sdk-components/src/components/infra/Assignment/Assignment.tsx
+++ b/packages/react-sdk-components/src/components/infra/Assignment/Assignment.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import AssignmentCard from '../AssignmentCard';
-import MultiStep from '../MultiStep';
 import Snackbar from '@material-ui/core/Snackbar';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 
 // import type { PConnProps } from '../../../types/PConnProps';
 
@@ -22,6 +21,10 @@ import CloseIcon from '@material-ui/icons/Close';
 
 
 export default function Assignment(props /* : AssignmentProps */) {
+  // Get emitted components from map (so we can get any override that may exist)
+  const AssignmentCard = getComponentFromMap("AssignmentCard");
+  const MultiStep = getComponentFromMap("MultiStep");
+
   const { getPConnect, children, itemKey = '', isInModal = false, banners = [] } = props;
   const thePConn = getPConnect();
 

--- a/packages/react-sdk-components/src/components/infra/AssignmentCard/AssignmentCard.tsx
+++ b/packages/react-sdk-components/src/components/infra/AssignmentCard/AssignmentCard.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import type { PConnProps } from '../../../types/PConnProps';
-
-import ActionButtons from "../ActionButtons";
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 
 interface AssignmentCardProps extends PConnProps {
   // If any, enter additional props that only exist on this component
@@ -14,6 +13,9 @@ interface AssignmentCardProps extends PConnProps {
 
 
 export default function AssignmentCard(props: AssignmentCardProps) {
+  // Get emitted components from map (so we can get any override that may exist)
+  const ActionButtons = getComponentFromMap("ActionButtons");
+
   const { children, actionButtons, onButtonPress} = props;
 
   const [arMainButtons, setArMainButtons] = useState([]);

--- a/packages/react-sdk-components/src/components/infra/Containers/FlowContainer/FlowContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/FlowContainer/FlowContainer.tsx
@@ -13,9 +13,7 @@ import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 
 import { addContainerItem, getToDoAssignments, showBanner } from './helpers';
 import { isEmptyObject } from '../../../helpers/common-utils';
-// Need to get correct implementation from component map for Assignment and ToDo
 import { getComponentFromMap } from '../../../../bridge/helpers/sdk_component_map';
-import AlertBanner from '../../../designSystemExtension/AlertBanner';
 
 // import type { PConnProps } from '../../../../types/PConnProps';
 
@@ -65,6 +63,7 @@ export default function FlowContainer(props /* : FlowContainerProps */) {
   // Get the proper implementation (local or Pega-provided) for these components that are emitted below
   const Assignment = getComponentFromMap('Assignment');
   const ToDo = getComponentFromMap('Todo'); // NOTE: ConstellationJS Engine uses "Todo" and not "ToDo"!!!
+  const AlertBanner = getComponentFromMap("AlertBanner");
 
   const pCoreConstants = PCore.getConstants();
   const PCoreVersion = PCore.getPCoreVersion();

--- a/packages/react-sdk-components/src/components/infra/MultiStep/MultiStep.tsx
+++ b/packages/react-sdk-components/src/components/infra/MultiStep/MultiStep.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 import './MultiStep.css';
 
-import AssignmentCard from '../AssignmentCard';
+// import AssignmentCard from '../AssignmentCard';
 
 // import { useConstellationContext } from "../../bridge/Context/StoreContext";
 
@@ -23,6 +23,9 @@ interface MultiStepProps extends PConnProps {
 
 
 export default function MultiStep(props: MultiStepProps) {
+    // Get emitted components from map (so we can get any override that may exist)
+    const AssignmentCard = getComponentFromMap("AssignmentCard");
+
     const { getPConnect, children, itemKey = '', actionButtons, onButtonPress} = props;
     const { bIsVertical, arNavigationSteps } = props;
 

--- a/packages/react-sdk-components/src/components/infra/MultiStep/MultiStep.tsx
+++ b/packages/react-sdk-components/src/components/infra/MultiStep/MultiStep.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 import './MultiStep.css';
 
-// import AssignmentCard from '../AssignmentCard';
-
 // import { useConstellationContext } from "../../bridge/Context/StoreContext";
 
 import type { PConnProps } from '../../../types/PConnProps';

--- a/packages/react-sdk-components/src/components/infra/VerticalTabs/VerticalTabs/VerticalTabs.tsx
+++ b/packages/react-sdk-components/src/components/infra/VerticalTabs/VerticalTabs/VerticalTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { makeStyles } from '@material-ui/core/styles'
 
 import Tabs from '@material-ui/core/Tabs';
-import LeftAlignVerticalTab from '../LeftAlignVerticalTabs';
+import { getComponentFromMap } from '../../../../bridge/helpers/sdk_component_map';
 
 // VerticalTabs does NOT have getPConnect. So, no need to extend from PConnProps
 interface VerticalTabsProps {
@@ -37,6 +37,9 @@ const createCustomEvent = (eventName: string, additionalData: {[key: string]: st
 
 
 export default function VerticalTabs(props: VerticalTabsProps) {
+  // Get emitted components from map (so we can get any override that may exist)
+  const LeftAlignVerticalTab = getComponentFromMap("LeftAlignVerticalTabs");
+
   // Get a React warning when we use tabConfig as mixed case. So all lowercase tabconfig
   const { tabconfig = [] } = props;
   const classes = useStyles();

--- a/packages/react-sdk-components/src/components/template/AppShell/AppShell.tsx
+++ b/packages/react-sdk-components/src/components/template/AppShell/AppShell.tsx
@@ -4,10 +4,7 @@ import { Utils } from '../../helpers/utils';
 import Avatar from '@material-ui/core/Avatar';
 import { NavContext } from '../../helpers/reactContextHelpers';
 import './AppShell.css';
-
-// AppShell can emit NavBar or WssNavBar
-import NavBar from '../../infra/NavBar';
-import WssNavBar from '../../template/WssNavBar';
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 
 import type { PConnProps } from '../../../types/PConnProps';
 
@@ -55,6 +52,10 @@ declare const PCore: any;
 
 
 export default function AppShell(props:AppShellProps) {
+  // Get emitted components from map (so we can get any override that may exist)
+  const NavBar = getComponentFromMap("NavBar");
+  const WssNavBar = getComponentFromMap("WssNavBar");
+
   const {
     pages = [],
     caseTypes = [],
@@ -66,6 +67,7 @@ export default function AppShell(props:AppShellProps) {
     portalLogo,
     navDisplayOptions
   } = props;
+
   const [open, setOpen] = useState(true);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   const [activeTab, setActiveTab] = useState(!pages ? null : pages[0]?.pyRuleName);

--- a/packages/react-sdk-components/src/components/template/CaseView/CaseView.tsx
+++ b/packages/react-sdk-components/src/components/template/CaseView/CaseView.tsx
@@ -9,9 +9,7 @@ import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 
 import StoreContext from '../../../bridge/Context/StoreContext';
-import CaseViewActionsMenu from '../CaseViewActionsMenu';
-import VerticalTabs from '../../infra/VerticalTabs/VerticalTabs';
-import DeferLoad from '../../infra/DeferLoad';
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 
 import type { PConnProps } from '../../../types/PConnProps';
 
@@ -58,6 +56,11 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export default function CaseView(props: CaseViewProps) {
+  // Get emitted components from map (so we can get any override that may exist)
+  const CaseViewActionsMenu = getComponentFromMap("CaseViewActionsMenu");
+  const VerticalTabs = getComponentFromMap("VerticalTabs");
+  const DeferLoad = getComponentFromMap("DeferLoad");
+
   const {
     getPConnect,
     icon = '',

--- a/packages/react-sdk-components/src/components/template/Confirmation/Confirmation.tsx
+++ b/packages/react-sdk-components/src/components/template/Confirmation/Confirmation.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function Confirmation(props: ConfirmationProps) {
   // Get emitted components from map (so we can get any override that may exist)
-  const ToDo = getComponentFromMap("ToDo");
+  const ToDo = getComponentFromMap("Todo"); // NOTE: ConstellationJS Engine uses "Todo" and not "ToDo"!!!
   const Details = getComponentFromMap("Details");
 
   const classes = useStyles();

--- a/packages/react-sdk-components/src/components/template/Confirmation/Confirmation.tsx
+++ b/packages/react-sdk-components/src/components/template/Confirmation/Confirmation.tsx
@@ -4,9 +4,9 @@
 import { Fragment, useState } from 'react';
 import React from 'react';
 import { getToDoAssignments } from '../../infra/Containers/FlowContainer/helpers';
-import ToDo from '../../widget/ToDo';
-import Details from '../Details/Details';
 import { Button, Card, makeStyles } from '@material-ui/core';
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
+
 import type { PConnProps } from '../../../types/PConnProps';
 
 // XX does NOT have getPConnect. So, no need to extend from PConnProps
@@ -36,6 +36,10 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export default function Confirmation(props: ConfirmationProps) {
+  // Get emitted components from map (so we can get any override that may exist)
+  const ToDo = getComponentFromMap("ToDo");
+  const Details = getComponentFromMap("Details");
+
   const classes = useStyles();
   const CONSTS = PCore.getConstants();
   const [showConfirmView, setShowConfirmView] = useState(true);

--- a/packages/react-sdk-components/src/components/template/InlineDashboardPage/InlineDashboardPage.tsx
+++ b/packages/react-sdk-components/src/components/template/InlineDashboardPage/InlineDashboardPage.tsx
@@ -27,7 +27,7 @@ export default function InlineDashboardPage(props: InlineDashboardPageProps) {
     return Children.toArray(children);
   }, [children]);
 
-  const allFilters = getPConnect().getRawMetadata()["children"][1];
+  const allFilters = getPConnect().getRawMetadata().children[1];
 
   useEffect(() => {
     setFilterComponents(buildFilterComponents(getPConnect, allFilters));

--- a/packages/react-sdk-components/src/components/template/InlineDashboardPage/InlineDashboardPage.tsx
+++ b/packages/react-sdk-components/src/components/template/InlineDashboardPage/InlineDashboardPage.tsx
@@ -27,7 +27,7 @@ export default function InlineDashboardPage(props: InlineDashboardPageProps) {
     return Children.toArray(children);
   }, [children]);
 
-  const allFilters = getPConnect().getRawMetadata().children[1];
+  const allFilters = getPConnect().getRawMetadata()["children"][1];
 
   useEffect(() => {
     setFilterComponents(buildFilterComponents(getPConnect, allFilters));

--- a/packages/react-sdk-components/src/components/template/InlineDashboardPage/InlineDashboardPage.tsx
+++ b/packages/react-sdk-components/src/components/template/InlineDashboardPage/InlineDashboardPage.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { useMemo, Children, useEffect, useState } from 'react';
 
 import { buildFilterComponents } from '../../infra/DashboardFilter/filterUtils';
-import InlineDashboard from '../InlineDashboard';
+import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
+
 import type { PConnProps } from '../../../types/PConnProps';
 
 
@@ -16,6 +17,9 @@ interface InlineDashboardPageProps extends PConnProps {
 
 
 export default function InlineDashboardPage(props: InlineDashboardPageProps) {
+  // Get emitted components from map (so we can get any override that may exist)
+  const InlineDashboard = getComponentFromMap("InlineDashboard");
+
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
   const { children, getPConnect, icon = '', filterPosition = 'block-start'  } = props;
   const [filterComponents, setFilterComponents] = useState([]);

--- a/packages/react-sdk-components/src/sdk-pega-component-map.js
+++ b/packages/react-sdk-components/src/sdk-pega-component-map.js
@@ -5,6 +5,7 @@
 
 import ActionButtons from '../src/components/infra/ActionButtons';
 import ActionButtonsForFileUtil from './components/widget/FileUtility/ActionButtonsForFileUtil';
+import AlertBanner from './components/designSystemExtension/AlertBanner';
 import AppAnnouncement from './components/widget/AppAnnouncement';
 import AppShell from './components/template/AppShell/AppShell';
 import Assignment from './components/infra/Assignment/Assignment';
@@ -109,6 +110,7 @@ import WssQuickCreate from './components/designSystemExtension/WssQuickCreate';
 const pegaSdkComponentMap = {
   'ActionButtons': ActionButtons,
   'ActionButtonsForFileUtil': ActionButtonsForFileUtil,
+  'AlertBanner': AlertBanner,
   'AppAnnouncement': AppAnnouncement,
   'AppShell': AppShell,
   'Assignment': Assignment,


### PR DESCRIPTION
This initial PR to get components from the Map (rather than importing) addresses all of the component imports I've found in files (**master** branch):

- designSystemExtension directory
- infra directory

It also includes files that used to have references to component imports from **../infra**, **../field**, **../template**, and **../widget** 