### PR TITLE
Mod/spr/fix get data object 8.8.20

### DIFF
--- a/packages/react-sdk-components/src/components/field/AutoComplete/AutoComplete.tsx
+++ b/packages/react-sdk-components/src/components/field/AutoComplete/AutoComplete.tsx
@@ -130,7 +130,7 @@ export default function AutoComplete(props: AutoCompleteProps) {
 
   useEffect(() => {
     if (listType === 'associated') {
-      setOptions(Utils.getOptionList(props, getPConnect().getDataObject('')));
+      setOptions(Utils.getOptionList(props, getPConnect().getDataObject(context)));
     }
   }, [theDatasource]);
 

--- a/packages/react-sdk-components/src/components/field/Dropdown/Dropdown.tsx
+++ b/packages/react-sdk-components/src/components/field/Dropdown/Dropdown.tsx
@@ -55,7 +55,7 @@ export default function Dropdown(props: DropdownProps) {
   const refName = propName?.slice(propName.lastIndexOf('.') + 1);
 
   useEffect(() => {
-    const list = Utils.getOptionList(props, getPConnect().getDataObject('')); // 1st arg empty string until typedef marked correctly
+    const list = Utils.getOptionList(props, getPConnect().getDataObject(thePConn.getContextName())); // 1st arg empty string until typedef marked correctly
     const optionsList = [...list];
     optionsList.unshift({
       key: placeholder,

--- a/packages/react-sdk-components/src/components/field/Dropdown/Dropdown.tsx
+++ b/packages/react-sdk-components/src/components/field/Dropdown/Dropdown.tsx
@@ -55,7 +55,7 @@ export default function Dropdown(props: DropdownProps) {
   const refName = propName?.slice(propName.lastIndexOf('.') + 1);
 
   useEffect(() => {
-    const list = Utils.getOptionList(props, getPConnect().getDataObject(thePConn.getContextName())); // 1st arg empty string until typedef marked correctly
+    const list = Utils.getOptionList(props, getPConnect().getDataObject(thePConn.getContextName()));
     const optionsList = [...list];
     optionsList.unshift({
       key: placeholder,

--- a/packages/react-sdk-components/src/components/field/RadioButtons/RadioButtons.tsx
+++ b/packages/react-sdk-components/src/components/field/RadioButtons/RadioButtons.tsx
@@ -53,7 +53,7 @@ export default function RadioButtons(props: RadioButtonsProps) {
 
   // theOptions will be an array of JSON objects that are literally key/value pairs.
   //  Ex: [ {key: "Basic", value: "Basic"} ]
-  const theOptions = Utils.getOptionList(theConfigProps, thePConn.getDataObject(''));
+  const theOptions = Utils.getOptionList(theConfigProps, thePConn.getDataObject(thePConn.getContextName()));
 
   useEffect(() => {
     // This update theSelectedButton which will update the UI to show the selected button correctly

--- a/packages/react-sdk-components/src/components/infra/Assignment/Assignment.tsx
+++ b/packages/react-sdk-components/src/components/infra/Assignment/Assignment.tsx
@@ -81,7 +81,7 @@ export default function Assignment(props: AssignmentProps) {
 
       const oWorkItem = children[0].props.getPConnect();
       const oWorkData = oWorkItem.getDataObject();
-      const oData = thePConn.getDataObject(thePConn.getContextName());  // 1st arg empty string until typedefs allow it to be optional
+      const oData = thePConn.getDataObject(thePConn.getContextName());
 
       if (oWorkData?.caseInfo && oWorkData.caseInfo.assignments !== null) {
         const oCaseInfo = oData.caseInfo;

--- a/packages/react-sdk-components/src/components/infra/Assignment/Assignment.tsx
+++ b/packages/react-sdk-components/src/components/infra/Assignment/Assignment.tsx
@@ -81,7 +81,7 @@ export default function Assignment(props: AssignmentProps) {
 
       const oWorkItem = children[0].props.getPConnect();
       const oWorkData = oWorkItem.getDataObject();
-      const oData = thePConn.getDataObject('');  // 1st arg empty string until typedefs allow it to be optional
+      const oData = thePConn.getDataObject(thePConn.getContextName());  // 1st arg empty string until typedefs allow it to be optional
 
       if (oWorkData?.caseInfo && oWorkData.caseInfo.assignments !== null) {
         const oCaseInfo = oData.caseInfo;

--- a/packages/react-sdk-components/src/components/infra/Containers/ModalViewContainer/ModalViewContainer.tsx
+++ b/packages/react-sdk-components/src/components/infra/Containers/ModalViewContainer/ModalViewContainer.tsx
@@ -208,8 +208,8 @@ export default function ModalViewContainer(props: ModalViewContainerProps) {
           const newComp = configObject.getPConnect();
           // const newCompName = newComp.getComponentName();
           const caseInfo =
-            newComp && newComp.getDataObject() && newComp.getDataObject().caseInfo
-              ? newComp.getDataObject().caseInfo
+            newComp && newComp.getDataObject() && newComp.getDataObject(newComp.getContextName()).caseInfo
+              ? newComp.getDataObject(newComp.getContextName()).caseInfo
               : null;
 
           // console.log(`ModalViewContainer just created newComp: ${newCompName}`);

--- a/packages/react-sdk-components/src/components/infra/DeferLoad/DeferLoad.tsx
+++ b/packages/react-sdk-components/src/components/infra/DeferLoad/DeferLoad.tsx
@@ -70,7 +70,7 @@ export default function DeferLoad(props /* : DeferLoadProps */) {
 
   const getViewOptions = () => ({
     viewContext: resourceType,
-    pageClass: loadViewCaseID ? '' : pConnect.getDataObject('').pyPortal.classID,  // 2nd arg empty string until typedef allows optional
+    pageClass: loadViewCaseID ? '' : pConnect.getDataObject(pConnect.getContextName()).pyPortal.classID,  // 2nd arg empty string until typedef allows optional
     container: isContainerPreview ? 'preview' : null,
     containerName: isContainerPreview ? 'preview' : null,
     updateData: isContainerPreview

--- a/packages/react-sdk-components/src/components/infra/DeferLoad/DeferLoad.tsx
+++ b/packages/react-sdk-components/src/components/infra/DeferLoad/DeferLoad.tsx
@@ -70,7 +70,7 @@ export default function DeferLoad(props /* : DeferLoadProps */) {
 
   const getViewOptions = () => ({
     viewContext: resourceType,
-    pageClass: loadViewCaseID ? '' : pConnect.getDataObject(pConnect.getContextName()).pyPortal.classID,  // 2nd arg empty string until typedef allows optional
+    pageClass: loadViewCaseID ? '' : pConnect.getDataObject(pConnect.getContextName()).pyPortal.classID,
     container: isContainerPreview ? 'preview' : null,
     containerName: isContainerPreview ? 'preview' : null,
     updateData: isContainerPreview


### PR DESCRIPTION
As of 8.8.4, passing an empty string as an argument to getDataObject breaks things. Should pass the current "context" (which can be obtained the the current PConnect's getContextName()