### PR TITLE
fix "Each child in a list should have a unique key" Error

### DIFF
--- a/packages/react-sdk-components/src/bridge/react_pconnect.jsx
+++ b/packages/react-sdk-components/src/bridge/react_pconnect.jsx
@@ -263,7 +263,7 @@ const createPConnectComponent = () => {
       if (getPConnect().hasChildren() && getPConnect().getChildren()) {
         return getPConnect()
           .getChildren()
-          .map(childProps => <PConnect {...childProps} />);
+          .map((childProps, index) => <PConnect {...childProps} key={this.getKey() + index} />);
       }
       return null;
     }


### PR DESCRIPTION
When using `createPConnectComponent` (for embedded mode), the following error shows in console:

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `PConnect`. See https://reactjs.org/link/warning-keys for more information.
    at PConnect (http://localhost:3502/node_modules/.vite/deps/chunk-CX4HZK3X.js?v=c14fdd4c:63400:7)
    at PConnect (http://localhost:3502/node_modules/.vite/deps/chunk-CX4HZK3X.js?v=c14fdd4c:63400:7)
    at RootComponent (http://localhost:3502/src/utils/RootComponent.tsx:17:33)
    at EmbedContext (http://localhost:3502/src/utils/EmbedContext.tsx:13:32)
    at ThemeProvider (http://localhost:3502/node_modules/.vite/deps/chunk-6HDHCNEB.js?v=c14fdd4c:7066:25)
    at EmbedContext (http://localhost:3502/src/utils/EmbedContext.tsx:13:32)
```

This PR fixes this error (adding a key to children of PConnect).