### PR TITLE
only copy necessary tinymce file from modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,8 +65,8 @@ module.exports = (env, argv) => {
           to: './'
         },
         {
-          from: './node_modules/tinymce',
-          to: './tinymce'
+          from: './node_modules/tinymce/tinymce.min.js',
+          to: './tinymce/tinymce.min.js'
         },
         {
           from: './node_modules/@pega/constellationjs/dist/bootstrap-shell.js',


### PR DESCRIPTION
Copy only tinymce.min.js instead of entire folder

```
{
  from: './node_modules/tinymce/tinymce.min.js',
  to: './tinymce/tinymce.min.js'
}
```