### PR TITLE
Display currency symbol in decimal

### DIFF
--- a/packages/react-sdk-components/src/components/field/Decimal/Decimal.tsx
+++ b/packages/react-sdk-components/src/components/field/Decimal/Decimal.tsx
@@ -15,6 +15,7 @@ interface DecimalProps extends PConnFieldProps {
   currencyISOCode?: string;
   decimalPrecision?: number;
   showGroupSeparators?: string;
+  formatter?: string;
 }
 
 export default function Decimal(props: DecimalProps) {
@@ -38,7 +39,8 @@ export default function Decimal(props: DecimalProps) {
     decimalPrecision = 2,
     showGroupSeparators = true,
     testId,
-    placeholder
+    placeholder,
+    formatter
   } = props;
 
   const pConn = getPConnect();
@@ -87,7 +89,7 @@ export default function Decimal(props: DecimalProps) {
       outputFormat='number'
       textAlign='left'
       InputProps={{ inputProps: { ...testProp } }}
-      currencySymbol={theCurrSym}
+      currencySymbol={readOnly && formatter === 'Currency' ? theCurrSym : ''}
       decimalCharacter={theCurrDec}
       digitGroupSeparator={showGroupSeparators ? theCurrSep : ''}
       decimalPlaces={decimalPrecision}

--- a/packages/react-sdk-components/src/components/field/Decimal/Decimal.tsx
+++ b/packages/react-sdk-components/src/components/field/Decimal/Decimal.tsx
@@ -49,6 +49,7 @@ export default function Decimal(props: DecimalProps) {
   const theSymbols = getCurrencyCharacters(currencyISOCode);
   const theCurrDec = theSymbols.theDecimalIndicator;
   const theCurrSep = theSymbols.theDigitGroupSeparator;
+  const theCurrSym = theSymbols.theCurrencySymbol;
 
   const theCurrencyOptions = getCurrencyOptions(currencyISOCode);
   const formattedValue = format(value, pConn.getComponentName().toLowerCase(), theCurrencyOptions);
@@ -86,7 +87,7 @@ export default function Decimal(props: DecimalProps) {
       outputFormat='number'
       textAlign='left'
       InputProps={{ inputProps: { ...testProp } }}
-      currencySymbol=''
+      currencySymbol={theCurrSym}
       decimalCharacter={theCurrDec}
       digitGroupSeparator={showGroupSeparators ? theCurrSep : ''}
       decimalPlaces={decimalPrecision}

--- a/packages/react-sdk-components/src/components/field/Decimal/Decimal.tsx
+++ b/packages/react-sdk-components/src/components/field/Decimal/Decimal.tsx
@@ -54,7 +54,13 @@ export default function Decimal(props: DecimalProps) {
   const theCurrSym = theSymbols.theCurrencySymbol;
 
   const theCurrencyOptions = getCurrencyOptions(currencyISOCode);
-  const formattedValue = format(value, pConn.getComponentName().toLowerCase(), theCurrencyOptions);
+
+  let formattedValue = '';
+  if (formatter === 'Currency') {
+    formattedValue = format(value, formatter.toLowerCase(), theCurrencyOptions);
+  } else {
+    formattedValue = format(value, pConn.getComponentName().toLowerCase(), theCurrencyOptions);
+  }
 
   if (displayMode === 'LABELS_LEFT') {
     return <FieldValueList name={hideLabel ? '' : label} value={formattedValue} />;

--- a/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Decimal.spec.js
+++ b/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Decimal.spec.js
@@ -94,6 +94,13 @@ test.describe('E2E test', () => {
     attributes = await common.getAttributes(editableDecimal);
     await expect(attributes.includes('readonly')).toBeFalsy();
 
+    const decimalAsCurrency = page.locator('input[data-test-id="9e438afab6d7ec67b5582bded10f5172"]');
+    attributes = await common.getAttributes(decimalAsCurrency);
+    await expect(attributes.includes('readonly')).toBeTruthy();
+    await expect(await decimalAsCurrency.inputValue()).toBe('20.00');
+    const symbol = page.locator('div:has-text("DecimalAsCurrency")');
+    await expect(symbol.locator('p:has-text("$")')).toBeTruthy();
+
     /** Selecting Visibility from the Sub Category dropdown */
     selectedSubCategory = page.locator('div[data-test-id="9463d5f18a8924b3200b56efaad63bda"]');
     await selectedSubCategory.click();


### PR DESCRIPTION
Updated decimal component. when decimal is read only and displayed as currency, no currency symbol was displayed. After this change will be able to see currency symbol in UI.