### PR TITLE
Fix ListView data page params not being passed issue

### DIFF
--- a/packages/react-sdk-components/src/components/infra/Reference/Reference.tsx
+++ b/packages/react-sdk-components/src/components/infra/Reference/Reference.tsx
@@ -36,7 +36,7 @@ export default function Reference(props: ReferenceProps) {
 
   // @ts-ignore - Argument of type 'null' is not assignable to parameter of type 'string'.
   const viewComponent: any = pConnect.createComponent(viewObject, null, null, {
-    pageReference: context
+    pageReference: context && context.startsWith('@CLASS') ? '' : context
   });
 
   viewComponent.props.getPConnect().setInheritedConfig({


### PR DESCRIPTION
* Fixed the data page parameters not being passed within the ListView component.
* The parameters which were referring to a field(which in turn was referring to a constant) were working, but the problem was with the parameters which were referring to a field(which in turn referring to a property).
* Please refer BUG-866299 for more details.