### PR TITLE
Add playwright tests for missing scanrios in Form Fields

### DIFF
--- a/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Email.spec.js
+++ b/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Email.spec.js
@@ -43,9 +43,17 @@ test.describe('E2E test', () => {
 
     /** Required tests */
     const requiredEmail = page.locator('input[data-test-id="96fa7548c363cdd5adb29c2c2749e436"]');
-
     requiredEmail.fill('John@doe.com');
     await expect(page.locator('p.Mui-error.Mui-required')).toBeHidden();
+
+    /** Checking 'field label', 'placeholder', and 'helper text' */
+    const requiredEmailFieldLabel = page.locator('text="Required Email"');
+    await expect(requiredEmailFieldLabel && requiredEmailFieldLabel.locator('text="*"')).toBeVisible();
+
+    const placeholderValue = await requiredEmail.getAttribute('placeholder');
+    await expect(placeholderValue).toBe('Email Placeholder');
+
+    await expect(page.locator('div[id="Assignment"] >> p:has-text("Email Helper Text")')).toBeVisible();
 
     attributes = await common.getAttributes(requiredEmail);
     await expect(attributes.includes('required')).toBeTruthy();

--- a/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Phone.spec.js
+++ b/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Phone.spec.js
@@ -39,6 +39,16 @@ test.describe('E2E test', () => {
 
     /** Required tests */
     const requiredPhone = page.locator('div[data-test-id="af983eaa1b85b015a7654702abd0b249"] >> input');
+
+    /** Checking 'field label', 'placeholder', and 'helper text' */
+    const requiredPhoneFieldLabel = page.locator('text="Required Phone"');
+    await expect(requiredPhoneFieldLabel && requiredPhoneFieldLabel.locator('text="*"')).toBeVisible();
+
+    const placeholderValue = await requiredPhone.getAttribute('placeholder');
+    await expect(placeholderValue).toBe('Phone Placeholder');
+
+    await expect(page.locator('div[id="Assignment"] >> p:has-text("Phone Helper Text")')).toBeVisible();
+
     attributes = await common.getAttributes(requiredPhone);
     await expect(attributes.includes('required')).toBeTruthy();
 

--- a/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Picklist.spec.js
+++ b/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Picklist.spec.js
@@ -37,6 +37,12 @@ test.describe('E2E test', () => {
     await page.getByRole('option', { name: 'Dropdown' }).click();
 
     const dropdown = page.locator('div[data-test-id="94cb322b7468c7827d336398e525827e"]');
+    /** Checking 'placeholder' and 'helper text' */
+    const placeholderValue = await dropdown.locator('input').getAttribute('placeholder');
+    await expect(placeholderValue).toBe('Select...');
+
+    await expect(page.locator('div[id="Assignment"] >> p:has-text("Picklist Helper Text")')).toBeVisible();
+
     await dropdown.click();
     await page.getByRole('option', { name: 'Massachusetts' }).click();
 


### PR DESCRIPTION
* Add playwright tests for the missing scenarios in the Form Fields.
* Please refer US-611865 for more details.