### PR TITLE
fix: SDK-R Phone number can't clear client validation error

### DIFF
--- a/packages/react-sdk-components/src/components/field/Phone/Phone.tsx
+++ b/packages/react-sdk-components/src/components/field/Phone/Phone.tsx
@@ -1,7 +1,9 @@
 import MuiPhoneNumber from 'material-ui-phone-number';
+import { useEffect, useState } from 'react';
 
 import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 import { PConnFieldProps } from '../../../types/PConnProps';
+import handleEvent from '../../helpers/event-utils';
 
 interface PhoneProps extends PConnFieldProps {
   // If any, enter additional props that only exist on Phone here
@@ -12,6 +14,7 @@ export default function Phone(props: PhoneProps) {
   const FieldValueList = getComponentFromMap('FieldValueList');
 
   const {
+    getPConnect,
     label,
     required,
     disabled,
@@ -19,7 +22,6 @@ export default function Phone(props: PhoneProps) {
     validatemessage,
     status,
     onChange,
-    onBlur,
     readOnly,
     testId,
     helperText,
@@ -27,6 +29,14 @@ export default function Phone(props: PhoneProps) {
     hideLabel,
     placeholder
   } = props;
+
+  const pConn = getPConnect();
+  const actions = pConn.getActionsApi();
+  const propName = (pConn.getStateProps() as any).value;
+
+  const [inputValue, setInputValue] = useState(value);
+  useEffect(() => setInputValue(value), [value]);
+
   const helperTextToDisplay = validatemessage || helperText;
 
   let testProp = {};
@@ -69,15 +79,14 @@ export default function Phone(props: PhoneProps) {
   }
 
   const handleChange = inputVal => {
-    let phoneValue = inputVal && inputVal.replace(/\D+/g, '');
-    phoneValue = `+${phoneValue}`;
-    onChange({ value: phoneValue });
+    setInputValue(inputVal);
   };
 
   const handleBlur = event => {
     const phoneValue = event?.target?.value;
-    event.target.value = `+${phoneValue && phoneValue.replace(/\D+/g, '')}`;
-    onBlur(event);
+    let phoneNumber = phoneValue.split(' ').slice(1).join();
+    phoneNumber = phoneNumber ? `+${phoneValue && phoneValue.replace(/\D+/g, '')}` : '';
+    handleEvent(actions, 'changeNblur', propName, phoneNumber);
   };
 
   return (
@@ -94,7 +103,7 @@ export default function Phone(props: PhoneProps) {
       onBlur={!readOnly ? handleBlur : undefined}
       error={status === 'error'}
       label={label}
-      value={value}
+      value={inputValue}
       InputProps={{ ...testProp }}
     />
   );

--- a/packages/react-sdk-components/tests/common.js
+++ b/packages/react-sdk-components/tests/common.js
@@ -59,6 +59,12 @@ const calculateCoverage = async (page, outputDir) => {
   await page.close();
 };
 
+const enterPhoneNumber = async (phone, number) => {
+  const phoneInput = phone.locator('input');
+  await phoneInput.click();
+  await phoneInput.pressSequentially(number);
+};
+
 module.exports = {
   launchPortal,
   launchEmbedded,
@@ -66,5 +72,6 @@ module.exports = {
   login,
   getAttributes,
   getFutureDate,
-  calculateCoverage
+  calculateCoverage,
+  enterPhoneNumber
 };

--- a/packages/react-sdk-components/tests/e2e/Digv2/ComplexFields/EmbeddedData.spec.js
+++ b/packages/react-sdk-components/tests/e2e/Digv2/ComplexFields/EmbeddedData.spec.js
@@ -127,8 +127,7 @@ test.describe('E2E test', () => {
     await phone.locator('button').click();
     /** Selecting the country code */
     await page.locator('text=United States+1 >> nth=0').click();
-    await phone.locator('input').click();
-    await phone.locator('input').pressSequentially('6175551212');
+    await common.enterPhoneNumber(phone, '6175551212');
 
     /** Creating second row by clicking on `+Add` button */
     await page.locator('a:has-text("+ Add")').click();
@@ -143,8 +142,7 @@ test.describe('E2E test', () => {
     await phone.locator('button').click();
     /** Selecting the country code */
     await page.locator('text=United States+1 >> nth=0').click();
-    await phone.locator('input').click();
-    await phone.locator('input').pressSequentially('6175451212');
+    await common.enterPhoneNumber(phone, '6175451212');
 
     await page.locator('button:has-text("Next")').click();
 
@@ -241,8 +239,7 @@ test.describe('E2E test', () => {
     await phone.locator('button').click();
     /** Selecting the country code */
     await page.locator('text=United States+1 >> nth=0').click();
-    await phone.locator('input').click();
-    await phone.locator('input').pressSequentially('6175551212');
+    await common.enterPhoneNumber(phone, '6175551212');
 
     const country = modal.locator('div[data-test-id="59716c97497eb9694541f7c3d37b1a4d"]');
     await country.click();
@@ -335,8 +332,7 @@ test.describe('E2E test', () => {
     await phone.locator('button').click();
     /** Selecting the country code */
     await page.locator('text=United States+1 >> nth=0').click();
-    await phone.locator('input').click();
-    await phone.locator('input').pressSequentially('6175551212');
+    await common.enterPhoneNumber(phone, '6175551212');
 
     let countryName = page.locator('div[data-test-id="59716c97497eb9694541f7c3d37b1a4d"]');
     await countryName.click();
@@ -355,8 +351,7 @@ test.describe('E2E test', () => {
     await phone.locator('button').click();
     /** Selecting the country code */
     await page.locator('text=United States+1 >> nth=0').click();
-    await phone.locator('input').click();
-    await phone.locator('input').pressSequentially('6175451212');
+    await common.enterPhoneNumber(phone, '6175451212');
 
     countryName = page.locator('div[data-test-id="59716c97497eb9694541f7c3d37b1a4d"] >> nth=1');
     await countryName.click();

--- a/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Phone.spec.js
+++ b/packages/react-sdk-components/tests/e2e/Digv2/FormFields/Phone.spec.js
@@ -93,17 +93,15 @@ test.describe('E2E test', () => {
     await countrySelector.click();
     await page.locator('text=United States+1 >> nth=0').click();
     const editablePhoneInput = editablePhone.locator('input');
-    await editablePhoneInput.click();
-    await editablePhoneInput.pressSequentially('6175551212');
+    await common.enterPhoneNumber(editablePhone, '6175551212');
 
     /** Validation tests */
     const validationMsg = 'Enter a valid phone number';
     await editablePhoneInput.clear();
     await countrySelector.click();
     await page.locator('text=United States+1 >> nth=0').click();
-    await editablePhoneInput.click();
     /** Entering an invalid Phone number */
-    await editablePhoneInput.pressSequentially('61');
+    await common.enterPhoneNumber(editablePhone, '61');
     await editablePhoneInput.blur();
     /** Expecting an error for Invalid phone number */
     await expect(page.locator(`p:has-text("${validationMsg}")`)).toBeVisible();
@@ -112,8 +110,7 @@ test.describe('E2E test', () => {
     await editablePhoneInput.clear();
     await countrySelector.click();
     await page.locator('text=United States+1 >> nth=0').click();
-    await editablePhoneInput.click();
-    await editablePhoneInput.pressSequentially('6175551212');
+    await common.enterPhoneNumber(editablePhone, '6175551212');
 
     await editablePhoneInput.blur();
     /** Expecting the invalid Phone number error be no longer present */

--- a/packages/react-sdk-components/tests/e2e/Digv2/ViewTemplates/Confirmation.spec.js
+++ b/packages/react-sdk-components/tests/e2e/Digv2/ViewTemplates/Confirmation.spec.js
@@ -47,9 +47,7 @@ test.describe('E2E test', () => {
     const countrySelector = phone.locator('button');
     await countrySelector.click();
     await page.locator('text=United States+1 >> nth=0').click();
-    const phoneInput = phone.locator('input');
-    await phoneInput.click();
-    await phoneInput.pressSequentially('6175551212');
+    await common.enterPhoneNumber(phone, '6175551212');
 
     await page.locator('button:has-text("submit")').click();
 

--- a/packages/react-sdk-components/tests/e2e/MediaCo/embedded.spec.js
+++ b/packages/react-sdk-components/tests/e2e/MediaCo/embedded.spec.js
@@ -60,9 +60,7 @@ test.describe('E2E test', () => {
     const countrySelector = phone.locator('button');
     await countrySelector.click();
     await page.locator('text=United States+1 >> nth=0').click();
-    const phoneInput = phone.locator('input');
-    await phoneInput.click();
-    await phoneInput.pressSequentially('6175551212');
+    await common.enterPhoneNumber(phone, '6175551212');
 
     await page.locator('button:has-text("next")').click();
 

--- a/packages/react-sdk-components/tests/e2e/MediaCo/portal.spec.js
+++ b/packages/react-sdk-components/tests/e2e/MediaCo/portal.spec.js
@@ -72,9 +72,7 @@ test.describe('E2E test', () => {
     const countrySelector = phone.locator('button');
     await countrySelector.click();
     await page.locator('text=United States+1 >> nth=0').click();
-    const phoneInput = phone.locator('input');
-    await phoneInput.click();
-    await phoneInput.pressSequentially('6175551212');
+    await common.enterPhoneNumber(phone, '6175551212');
 
     await page.locator('button:has-text("submit")').click();
 


### PR DESCRIPTION
Current Behavior: When you enter a number on phone number which is not a required field on the form, and after clearing the phone number it is showing validation error message

Expected Behavior: Shouldn't show validation message on clear