### PR TITLE
 T-37145: Boolean label isn't visible in details view

### DIFF
--- a/packages/react-sdk-components/src/components/field/Checkbox/Checkbox.tsx
+++ b/packages/react-sdk-components/src/components/field/Checkbox/Checkbox.tsx
@@ -124,11 +124,11 @@ export default function CheckboxComponent(props: CheckboxProps) {
   }, [value]);
 
   if (displayMode === 'DISPLAY_ONLY') {
-    return <FieldValueList name={hideLabel ? '' : caption} value={value ? trueLabel : falseLabel} />;
+    return <FieldValueList name={caption} value={value ? trueLabel : falseLabel} />;
   }
 
   if (displayMode === 'STACKED_LARGE_VAL') {
-    return <FieldValueList name={hideLabel ? '' : caption} value={value ? trueLabel : falseLabel} variant='stacked' />;
+    return <FieldValueList name={caption} value={value ? trueLabel : falseLabel} variant='stacked' />;
   }
 
   const handleChange = event => {


### PR DESCRIPTION
<img width="936" height="457" alt="image" src="https://github.com/user-attachments/assets/f3f68589-690b-4608-973e-001063d81021" />

This was the issue. in the constellation code, the checking for hidelabel is not being done. so removed that in SDK repo as well 
here is the code snippet from the constellation repo 

<img width="1020" height="131" alt="Screenshot 2026-07-17 at 2 13 39 PM" src="https://github.com/user-attachments/assets/4abebac4-03ff-41f6-9a5c-665b29069747" />

the below is the screenshot after the fix 

<img width="764" height="485" alt="Screenshot 2026-07-17 at 2 14 36 PM" src="https://github.com/user-attachments/assets/9457cf33-add3-418a-bd7c-d4a62c07a9fa" />
