### PR TITLE
Fixed issued with DataReference

### DIFF
--- a/packages/react-sdk-components/src/components/field/AutoComplete/AutoComplete.tsx
+++ b/packages/react-sdk-components/src/components/field/AutoComplete/AutoComplete.tsx
@@ -7,7 +7,6 @@ import isDeepEqual from 'fast-deep-equal/react';
 
 import Utils from '../../helpers/utils';
 import { getDataPage } from '../../helpers/data_page';
-import handleEvent from '../../helpers/event-utils';
 import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 import type { PConnFieldProps } from '../../../types/PConnProps';
 import useStatus from '../../../hooks/useStatus';
@@ -117,7 +116,7 @@ export default function AutoComplete(props: AutoCompleteProps) {
   const [inputValue, setInputValue] = useState('');
   const [options, setOptions] = useState<IOption[]>([]);
   const [theDatasource, setDatasource] = useState(null);
-  let selectedValue: any = '';
+  let selectedValue: any = null;
   const eligibleForFieldWarning = showFieldMessage && messageConfig.visibility && !readOnly;
   const helperTextToDisplay = validatemessage || (eligibleForFieldWarning ? messageConfig.content : helperText);
 
@@ -296,16 +295,32 @@ export default function AutoComplete(props: AutoCompleteProps) {
     }
   }
 
+  useEffect(() => {
+    setInputValue(selectedValue || '');
+  }, [selectedValue]);
+
   const handleChange = (event: object, newValue) => {
     const val = newValue ? newValue.key : '';
-    handleEvent(actionsApi, 'changeNblur', propName, val);
+    if (!newValue) {
+      setInputValue('');
+    }
+    actionsApi.updateFieldValue(propName, val);
+    const changePromise = (actionsApi as any).triggerFieldChange(propName, val);
     if (onRecordChange) {
-      onRecordChange(event);
+      if (changePromise && changePromise.then) {
+        changePromise.then(() => {
+          onRecordChange({ ...event, id: val });
+        });
+      } else {
+        onRecordChange({ ...event, id: val });
+      }
     }
   };
 
-  const handleInputValue = (event, newInputValue) => {
-    setInputValue(newInputValue);
+  const handleInputValue = (event, newInputValue, reason) => {
+    if (reason === 'selectOption') {
+      setInputValue(newInputValue);
+    }
   };
 
   // Sets values for all columns that have setProperty defined (mirrors setValuesToOtherAdditionalFields in constellation-frontend)
@@ -480,7 +495,7 @@ export default function AutoComplete(props: AutoCompleteProps) {
       fullWidth
       onChange={handleChange}
       value={selectedValue}
-      inputValue={inputValue || selectedValue}
+      inputValue={inputValue}
       onInputChange={handleInputValue}
       filterOptions={createFilterOptions<IOption>({
         stringify: option => {

--- a/packages/react-sdk-components/src/components/field/AutoComplete/AutoComplete.tsx
+++ b/packages/react-sdk-components/src/components/field/AutoComplete/AutoComplete.tsx
@@ -11,6 +11,7 @@ import { getComponentFromMap } from '../../../bridge/helpers/sdk_component_map';
 import type { PConnFieldProps } from '../../../types/PConnProps';
 import useStatus from '../../../hooks/useStatus';
 import { getFieldSx } from '../../helpers/field-utils';
+import handleEvent from '../../helpers/event-utils';
 
 interface IOption {
   key: string;

--- a/packages/react-sdk-components/src/components/field/ObjectReference/ObjectReference.tsx
+++ b/packages/react-sdk-components/src/components/field/ObjectReference/ObjectReference.tsx
@@ -35,7 +35,6 @@ interface ObjectReferenceProps extends Omit<PConnFieldProps, 'value'> {
 }
 
 export default function ObjectReference(props: ObjectReferenceProps) {
-  console.log('Rendering ObjectReference with props', props);
   const {
     getPConnect,
     children,

--- a/packages/react-sdk-components/src/components/template/DataReference/DataReference.tsx
+++ b/packages/react-sdk-components/src/components/template/DataReference/DataReference.tsx
@@ -206,7 +206,22 @@ export default function DataReference(props: PropsWithChildren<DataReferenceProp
           .refreshCaseView(caseKey, viewName, pgRef, refreshOptions)
           .catch(() => {});
       }
-    } else if (propValue && canBeChangedInReviewMode && isDisplayModeEnabled) {
+    } else if (hasAssociatedViewConfigured || allowImplicitRefresh) {
+      const pageReference = pConn.getPageReference();
+      let pgRef: any = null;
+      if (pageReference.startsWith('objectInfo')) {
+        pgRef = pageReference.replace('objectInfo.content', '');
+      } else {
+        pgRef = pageReference.replace('caseInfo.content', '');
+      }
+      const viewName = rawViewMetadata.name;
+      getPConnect()
+        .getActionsApi()
+        .refreshCaseView(caseKey, viewName, pgRef, refreshOptions)
+        .catch(() => {});
+    }
+
+    if (propValue && canBeChangedInReviewMode && isDisplayModeEnabled) {
       (PCore.getDataApiUtils().getCaseEditLock(caseKey, '') as Promise<any>).then(caseResponse => {
         const pageTokens = pConn.getPageReference().replace('caseInfo.content', '').split('.');
         let curr = {};

--- a/packages/react-sdk-components/src/components/template/ListView/ListView.tsx
+++ b/packages/react-sdk-components/src/components/template/ListView/ListView.tsx
@@ -141,6 +141,10 @@ export default function ListView(props: ListViewProps) {
 
   const [selectedValue, setSelectedValue] = useState(value);
 
+  useEffect(() => {
+    setSelectedValue(value);
+  }, [value]);
+
   // Tracks selected row keys for multi-select mode (mirrors Angular's SelectionModel)
   const [selectedRowSet, setSelectedRowSet] = useState<Set<string>>(new Set());
 


### PR DESCRIPTION
Fixed a few issues:
* The Table doesn't reflect the updated value from the AutoComplete.
* AutoComplete generating duplicate options and showing console errors due to no proper key present.
* Removed a console statement from ObjectReference component.