### PR TITLE
BUG-1012427:Icon button display decision (bin vs menu) on attached files

### DIFF
--- a/packages/react-sdk-components/src/components/widget/Attachment/Attachment.tsx
+++ b/packages/react-sdk-components/src/components/widget/Attachment/Attachment.tsx
@@ -505,12 +505,12 @@ export default function Attachment(props: AttachmentProps) {
                 {item.props.meta && <div style={{ color: item.props.error ? 'red' : undefined }}>{item.props.meta}</div>}
               </div>
               <div className='psdk-utility-action'>
-                {item.ID && (
+                {(item.ID || item.responseProps?.localAttachment) && (
                   <button type='button' className='psdk-utility-button' aria-label='Delete Attachment' onClick={() => deleteFile(item, index)}>
                     <img className='psdk-utility-card-action-svg-icon' src={deleteIcon} />
                   </button>
                 )}
-                {!item.ID && (
+                {!item.ID && !item.responseProps?.localAttachment && (
                   <div>
                     <IconButton
                       id='setting-button'


### PR DESCRIPTION
In attachment component, based on whether file is sent to server or not the button on file is decided.

If the file is from server the 3 dots menu with download and delete option is shown
If the file is just uploaded then bin icon should be shown.